### PR TITLE
Static site integration

### DIFF
--- a/access/cdx/deploy-cdx-stack-dev.sh
+++ b/access/cdx/deploy-cdx-stack-dev.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker stack deploy -c docker-compose.yml cdx

--- a/access/cdx/docker-compose.yml
+++ b/access/cdx/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  outbackcdx:
+    image: nlagovau/outbackcdx:0.11.0
+    command: "java -Xmx8g -jar /outbackcdx.jar -d /cdx-data -b 0.0.0.0 -p 8080 -t 5000"
+    ports:
+      - "8080:8080"
+    volumes:
+      - /mnt/nfs/data/cdx:/cdx-data

--- a/access/website/config/nginx.conf
+++ b/access/website/config/nginx.conf
@@ -6,6 +6,10 @@ server {
     listen 80;
     proxy_read_timeout 600;
 
+    # Setup error pages:
+    error_page 404 /en/404.html;
+    error_page 500 /en/500.html;
+
     # NGINX merging // to / routinely causes problems for us, so lets switch it off:
     merge_slashes off;
 
@@ -104,6 +108,10 @@ server {
     rewrite ^/ukwa/collection/28180520/page/1(.*)$ /en/ukwa/collection/2450 permanent;
     rewrite ^/nominate /en/ukwa/info/nominate permanent;
     rewrite ^/cy/nominate /cy/ukwa/info/nominate permanent;
+    # Add redirects for true homepage:
+    rewrite ^/en/$ /en/ukwa/ permanent;
+    rewrite ^/cy/$ /cy/ukwa/ permanent;
+    rewrite ^/gd/$ /gd/ukwa/ permanent;
 
     # internal
 #       rewrite ^/wayback/memento/timegate/(.+)$ /wayback/archive/$1 permanent;
@@ -124,16 +132,20 @@ server {
             autoindex on;
     }
 
-    # 404 image randomiser:
-    location /404 {
-            root /var/www/ukwa-site/static/img;
-            random_index on;
-    }
-
     # Patch in static robots.txt etc.
     location / {
-	root /webroot;
-        try_files $uri @ukwaui;
+	root /usr/share/nginx/html;
+        try_files $uri $uri/ @ukwaui;
+        # 500 image randomiser:
+        location /img/500 {
+            random_index on;
+        }
+
+        # 404 image randomiser:
+        location /img/404 {
+            random_index on;
+        }
+
     }
 
     # default action - always last ---------------

--- a/access/website/config/nginx.conf
+++ b/access/website/config/nginx.conf
@@ -155,6 +155,8 @@ server {
             proxy_connect_timeout      	300s;
             proxy_read_timeout      	300s;
             proxy_send_timeout      	300s;
+            # Allow NGINX to handle errors
+            proxy_intercept_errors on; # see http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors
     }
 
 }

--- a/access/website/config/nginx.conf
+++ b/access/website/config/nginx.conf
@@ -6,10 +6,6 @@ server {
     listen 80;
     proxy_read_timeout 600;
 
-    # Setup error pages:
-    error_page 404 /en/404.html;
-    error_page 500 /en/500.html;
-
     # NGINX merging // to / routinely causes problems for us, so lets switch it off:
     merge_slashes off;
 
@@ -132,6 +128,10 @@ server {
             autoindex on;
     }
 
+    # Setup error pages:
+    error_page 404 /en/404.html;
+    error_page 500 /en/500.html;
+
     # Patch in static robots.txt etc.
     location / {
 	root /usr/share/nginx/html;
@@ -144,6 +144,15 @@ server {
         # 404 image randomiser:
         location /img/404 {
             random_index on;
+        }
+
+        location /cy/ {
+            error_page 404 /cy/404.html;
+            error_page 500 /cy/500.html;
+        }
+        location /gd/ {
+            error_page 404 /gd/404.html;
+            error_page 500 /gd/500.html;
         }
 
     }

--- a/access/website/config/static/robots.txt
+++ b/access/website/config/static/robots.txt
@@ -6,7 +6,7 @@ Disallow: /en/ukwa/search
 Disallow: /cy/ukwa/search
 Disallow: /gd/ukwa/search
 Disallow: /datasets/
-Disallow: /shine/
+Disallow: /shine/search
 
 # Allow Twitterbot so social cards work:
 User-agent: Twitterbot

--- a/access/website/docker-compose.yml
+++ b/access/website/docker-compose.yml
@@ -11,13 +11,13 @@ services:
   # -------------------------------------------------------------
   # All routing to sub-components goes through here.
   # All complex setup relating to the public website is here.
+  # Static content hosted within the container, including robots.txt
   nginx:
-    image: nginx:alpine
+    image: ukwa/ukwa-site:master
     ports:
       - "80:80"
     volumes:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./config/static:/webroot:ro
     depends_on:
       - shine
       - pywb
@@ -30,7 +30,7 @@ services:
   # -------------------------------------------------------------
   ukwa-ui:
     #image: ukwa/ukwa-ui:v1.3.4
-    image: min2ha/ukwa-ui:xss-solution
+    image: min2ha/ukwa-ui:master
     command: java -Djava.security.egd=file:/dev/./urandom -jar /ukwa-ui.war --spring.config.location=file:/application.properties
     environment:
      - "OFF_SITE_URL=/wayback/archive/"
@@ -182,7 +182,7 @@ services:
 
   # Collections index for Topics & Themes of the UKWA UI
   collections_solr:
-    image: ukwa/ukwa-ui-collections-solr:1.1.1
+    image: ukwa/ukwa-ui-collections-solr:1.2.0
     user: "${CURRENT_UID}"
     volumes:
         - "${STORAGE_PATH_WEBSITE}/collections_solr_cores:/opt/solr/server/solr/mycores"

--- a/access/website_tests/docker-compose.yml
+++ b/access/website_tests/docker-compose.yml
@@ -59,7 +59,4 @@ services:
     image: selenium/hub:3.141.59-zinc
     ports:
       - "4444:4444"
-    depends_on:
-      - firefox
-      - chrome
 


### PR DESCRIPTION
This pull request integrates the static site builder from ukwa/ukwa-site, making it possible to manage the textual website content via a simple CMS rather than everything being inside the UKWA-UI Java project.

It is not intended for merging yet, as there is higher priority work underway, and we want to keep things clear/separated.

Also need to consider:

- [ ] end user documentation/video showing how to edit content
- [ ] TBC!